### PR TITLE
[REVIEW] added templatefilter param in cs.listTemplates

### DIFF
--- a/dashboard/CloudStackApiClient.py
+++ b/dashboard/CloudStackApiClient.py
@@ -42,7 +42,7 @@ class CloudStackApiClient:
 
     def listTemplates(self, force=False):
         if force or len(self.tps) == 0:
-            tps = self._cs.listTemplates()
+            tps = self._cs.listTemplates(templatefilter="self")
             self.tps = [ (tp['id'], tp['name']) for tp in tps['template'] ]
         return self.tps
 		


### PR DESCRIPTION
Fixed https://github.com/leap-solutions-asia/auto-scaling/issues/5

Autoscale dashboard is unable to list template by using cs.listTemplates because templatefilter is required.

```
def listTemplates(self, force=False):
        if force or len(self.tps) == 0:
            tps = self._cs.listTemplates(templatefilter="self")
            self.tps = [ (tp['id'], tp['name']) for tp in tps['template'] ]
        return self.tps
```