### PR TITLE
[REVIEW]Correct get function, Force API calling, VM validation and display format

### DIFF
--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -144,8 +144,8 @@ def settings():
     
     tenant_lb_rule_uuid = conf.get_lb_rule_uuid()
     tenant_zone_uuid = conf.get_zone_uuid()
-    tenant_template_uuid = conf.get_lb_rule_uuid()
-    tenant_serviceoffering_uuid = conf.get_template_uuid()
+    tenant_template_uuid = conf.get_template_uuid()
+    tenant_serviceoffering_uuid = conf.get_serviceoffering_uuid()
     autoscaling_autoscaling_vm = conf.get_autoscaling_vm()
     autoscaling_upper_limit = conf.get_upper_limit()
     autoscaling_lower_limit = conf.get_lower_limit()
@@ -180,11 +180,11 @@ def settings():
 def editsettings():    
     form = EditSettingsForm()
     cs = CloudStackApiClient.get_instance()
-    form.template_uuid.choices = cs.listTemplates()
-    form.lb_rule_uuid.choices = cs.listLoadBalancerRules()
-    form.serviceoffering_uuid.choices = cs.listServiceOfferings()
-    form.zone_uuid.choices = cs.listZones()
-    form.vms.choices = cs.listVirtualMachines()
+    form.template_uuid.choices = cs.listTemplates(force=True)
+    form.lb_rule_uuid.choices = cs.listLoadBalancerRules(force=True)
+    form.serviceoffering_uuid.choices = cs.listServiceOfferings(force=True)
+    form.zone_uuid.choices = cs.listZones(force=True)
+    form.vms.choices = cs.listVirtualMachines(force=True)
     conf = CloudStackConfig()
     
     if form.validate_on_submit():

--- a/dashboard/forms.py
+++ b/dashboard/forms.py
@@ -38,8 +38,15 @@ class EditSettingsForm(FlaskForm):
         InputRequired(), 
         NumberRange(min=1, max=99, message='A number must be between (1-99)')
     ])
-    vms =   AutoScalingSelectMultipleField('vms', choices=[])
+    vms =   AutoScalingSelectMultipleField('VM List', choices=[])
     submit = SubmitField('Update')
+    
+    def validate_vms(self, extra):
+        if len(self.vms.data) < 1:
+            msg = 'Please select a single VM at least!'
+            self.vms.errors.append(msg)
+            return False
+        return True
     
     def validate_lower_limit(self, extra):
         if type(self.lower_limit.data) is not int or type(self.upper_limit.data) is not int:

--- a/dashboard/templates/credential.html
+++ b/dashboard/templates/credential.html
@@ -7,7 +7,7 @@
         
         {{ form.hidden_tag() }}
 
-        <div class="col-md-8">
+        <div class="col-md-20">
           <div class="content-section">
             <h3>Leap GIO API Settings</h3>
             <p>

--- a/dashboard/templates/settings.html
+++ b/dashboard/templates/settings.html
@@ -6,20 +6,20 @@
         <form method="POST" action="">
         {{ form.hidden_tag() }}
 		
-        <div class="col-md-8">
+        <div class="col-md-20">
           <div class="content-section">
             <h3>Autoscale Settings</h3>
             <p>
               <ul class="list-group">
-                <li class="list-group-item list-group-item-light">Scaling VM No. :{{ autoscaling_autoscaling_vm }}</li>
-                <li class="list-group-item list-group-item-light">Upper Limit : {{ autoscaling_upper_limit }}</li>
-                <li class="list-group-item list-group-item-light">Lower Limit : {{ autoscaling_lower_limit }}</li>
+                <li class="list-group-item list-group-item-light">Maximum number of instances :{{ autoscaling_autoscaling_vm }}</li>
+                <li class="list-group-item list-group-item-light">Threshold of Scale-up : {{ autoscaling_upper_limit }}</li>
+                <li class="list-group-item list-group-item-light">Threshold of Scale-down : {{ autoscaling_lower_limit }}</li>
               </ul>
             </p>
           </div>
         </div>
         
-        <div class="col-md-8">
+        <div class="col-md-20">
           <div class="content-section">
             <h3>Tenant Settings</h3>
             <p>
@@ -33,7 +33,7 @@
           </div>
         </div>
         
-        <div class="col-md-8">
+        <div class="col-md-20">
           <div class="content-section">
             <h3>VM list</h3>
             <p>


### PR DESCRIPTION
Fixed issue no. https://github.com/leap-solutions-asia/auto-scaling/issues/7

- Correct get function for Template and Serviceoffering in dashboard.py
- Force API call to get list every time in editsettings.html
- Validate VM data to be at least 1 VM in forms.py
- Adjust display format for credential and settings.html