### PR TITLE
ubuntu 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Auto Scaling for Leap GIO Public
 
-Just testing!
-
 ## Auto Scaling Controller and Dashboard
 
 ### Specifications
@@ -9,6 +7,7 @@ Just testing!
 Supported OS (Leap GIO Public Virtual Machine)
 * CentOS 7.x
 * Ubuntu 16.04
+* Ubuntu 18.04
 
 Dashboard ports
 * 8080-8084/tcp (allow 8080-8084/tcp iptables, firewalld or ufw)
@@ -41,6 +40,7 @@ Supported OS (Leap GIO Public Virtual Machine)
 * CentOS 7.x
 * Ubuntu 14.04
 * Ubuntu 16.04
+* Ubuntu 18.04
 
 Agent port
 * 8585/tcp (allow 8585/tcp iptables, firewalld or ufw)

--- a/setup/roles/agent/tasks/ufw.yml
+++ b/setup/roles/agent/tasks/ufw.yml
@@ -3,5 +3,5 @@
 - name: set 8585/tcp to ufw
   ufw:
     rule: allow
-    port: 8585
+    port: "8585"
     proto: tcp

--- a/setup/roles/docker-compose/vars/main.yml
+++ b/setup/roles/docker-compose/vars/main.yml
@@ -1,2 +1,3 @@
-url: https://github.com/docker/compose/releases/download/1.23.2/docker-compose-Linux-x86_64
-checksum: 4d618e19b91b9a49f36d041446d96a1a0a067c676330a4f25aca6bbd000de7a9
+url: https://github.com/docker/compose/releases/download/1.24.1/docker-compose-Linux-x86_64
+checksum: cfb3439956216b1248308141f7193776fcf4b9c9b49cbbe2fb07885678e2bb8a
+validate_certs: False

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -59,7 +59,7 @@ case "${ID}${VERSION_ID}" in
             yum -y install git ansible
         fi
         ;;
-    ubuntu16.04)
+    ubuntu16.04|ubuntu18.04)
         if [ "${install}" -eq "0" ]; then
             apt-get update
             apt-get install -y software-properties-common


### PR DESCRIPTION
Deal with ubuntu 18.04 because Leap GIO Public provides ubuntu 18.04.

* Deal with ubuntu 18.04
* Update version docker-compose from 1.23.2 to 1.24.1
* Fixed warning

Refer to https://github.com/leap-solutions-asia/auto-scaling/issues/28